### PR TITLE
Cast the list of query coordinates to float

### DIFF
--- a/intergrid/intergrid.py
+++ b/intergrid/intergrid.py
@@ -172,7 +172,7 @@ class Intergrid:
     def __call__( self, X, out=None ):
         """ query_values = Intergrid(...) ( query_points npt x dim )
         """
-        X = np.asanyarray(X)
+        X = np.asanyarray(X).astype(np.float)
         assert X.shape[-1] == self.dim, ("the query array must have %d columns, "
                 "but its shape is %s" % (self.dim, X.shape) )
         Xdim = X.ndim


### PR DESCRIPTION
In my case, X happened to be integral, which means that np.interp() didn't work as expected. Enforcing float type avoids this problem.

(Thanks for a great script!)
